### PR TITLE
add global index support using env var

### DIFF
--- a/init/bash
+++ b/init/bash
@@ -24,8 +24,10 @@ if [ ! -x "$MII" ]; then
     return
 fi
 
-# synchronize the index quietly and quickly
-(mii sync 2>/dev/null &) 
+# synchronize the index quietly and quickly if no global index
+if [ ! -x "$MII_INDEX_FILE" ]; then
+    (mii sync 2>/dev/null &)
+fi
 
 # execute the common handler
 command_not_found_handle() {

--- a/init/zsh
+++ b/init/zsh
@@ -24,8 +24,10 @@ if [ ! -x "$MII" ]; then
     return
 fi
 
-# synchronize the index quickly and quietly
-(mii sync 2>/dev/null &)
+# synchronize the index quickly and quietly if no global index
+if [ ! -x "$MII_INDEX_FILE" ]; then
+    (mii sync 2>/dev/null &)
+fi
 
 # execute the common handler
 command_not_found_handler() {

--- a/src/mii.c
+++ b/src/mii.c
@@ -39,7 +39,24 @@ int mii_init() {
         }
     }
 
-    if (!_mii_datadir) {
+    /* -d option has priority */
+    if (!_mii_datadir)
+    {
+        char *index_file = getenv("MII_INDEX_FILE");
+
+        /* can't read file if file exists */
+        if (index_file && (access(index_file, R_OK) != 0 && errno != ENOENT))
+        {
+            mii_error("%s exists and is not readable!", index_file);
+            return -1;
+        }
+
+        /* env var is set and file is OK */
+        if (index_file)
+        {
+            _mii_datafile = mii_strdup(index_file);
+        }
+
         char* home = getenv("HOME");
 
         if (!home) {
@@ -57,7 +74,10 @@ int mii_init() {
         return -1;
     }
 
-    _mii_datafile = mii_join_path(_mii_datadir, "index");
+    if (!_mii_datafile) 
+    {
+        _mii_datafile = mii_join_path(_mii_datadir, "index");
+    }
 
     mii_debug("Initialized mii with cache path %s", _mii_datafile);
     return 0;

--- a/src/mii.c
+++ b/src/mii.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libgen.h>
 
 #include <sys/stat.h>
 #include <unistd.h>
@@ -54,6 +55,20 @@ int mii_init() {
         /* env var is set and file is OK */
         if (index_file)
         {
+            char* index_file_cpy = mii_strdup(index_file);
+            char* mii_index_dir = dirname(index_file_cpy);
+
+            /* create parent dir */
+            int res = mii_recursive_mkdir(mii_index_dir, 0755);
+
+            free(index_file_cpy);
+
+            /* couldn't create index dir */
+            if (res) {
+                mii_error("Error initializing index directory: %s", strerror(errno));
+                return -1;
+            }
+
             _mii_datafile = mii_strdup(index_file);
         }
 

--- a/src/mii.c
+++ b/src/mii.c
@@ -45,14 +45,6 @@ int mii_init() {
     {
         char *index_file = getenv("MII_INDEX_FILE");
 
-        /* can't read file if file exists */
-        if (index_file && (access(index_file, R_OK) != 0 && errno != ENOENT))
-        {
-            mii_error("%s exists and is not readable!", index_file);
-            return -1;
-        }
-
-        /* env var is set and file is OK */
         if (index_file)
         {
             char* index_file_cpy = mii_strdup(index_file);

--- a/src/util.c
+++ b/src/util.c
@@ -8,6 +8,12 @@
 
 #include <ctype.h>
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+#include <libgen.h>
+
 char* mii_strdup(const char* str) {
     int len = strlen(str);
     char* out = malloc(len + 1);
@@ -67,4 +73,32 @@ int mii_levenshtein_distance(const char* a, const char* b) {
     free(mat);
 
     return result;
+}
+
+int mii_recursive_mkdir(const char *path, mode_t mode) {
+    int res;
+    struct stat st;
+
+    res = stat(path, &st);
+
+    /* file exists and is a directory, nothing to do */
+    if (!res && S_ISDIR(st.st_mode)) {
+        return 0;
+    }
+
+    /* file exists but isn't a directory */
+    if (!res) {
+        errno = ENOTDIR;
+        return -1;
+    }
+
+    /* create parent directory */
+    char *dir = strdup(path);
+    res = mii_recursive_mkdir(dirname(dir), mode);
+
+    free(dir);
+
+    if (res) return res;
+
+    return mkdir(path, mode);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sys/types.h>
+
 /* generic utils */
 
 #define mii_min(x, y) ((x < y) ? (x) : (y))
@@ -7,3 +9,4 @@
 char* mii_strdup(const char* str);
 char* mii_join_path(const char* a, const char* b);
 int mii_levenshtein_distance(const char* a, const char* b);
+int mii_recursive_mkdir(const char* path, mode_t mode);


### PR DESCRIPTION
This PR adds a way to use a global index specified by the `MII_INDEX_FILE` environment variable. If `MII_INDEX_FILE` is not set, the behaviour will be the same as previous versions of mii. If `MII_INDEX_FILE` is set, it will be used as the `_mii_datafile`. The behaviour for `_mii_datadir` remains unchanged, so disabling and enabling mii can be done on a per-user basis (the `disabled` file will be saved in `$HOME/.mii`).

Also disabled sync on sourcing shell integration if `MII_INDEX_FILE` is set, indicating a global index.

The parent directory of `MII_INDEX_FILE` needs to be created manually before generating the index.