### PR TITLE
check for transposition in levenshtein distance

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -34,7 +34,7 @@ char* mii_join_path(const char* a, const char* b) {
 
 int mii_levenshtein_distance(const char* a, const char* b) {
     /*
-     * quickly compute the levenshtein distance between
+     * quickly compute the damerau-levenshtein distance between
      * string <a> and <b> using a full matrix
      */
 
@@ -57,6 +57,11 @@ int mii_levenshtein_distance(const char* a, const char* b) {
             int substitution = mat[(i - 1) * (b_len + 1) + j - 1] + (tolower(a[i - 1]) != tolower(b[j - 1]));
 
             mat[i * (b_len + 1) + j] = mii_min(deletion, mii_min(insertion, substitution));
+
+            /* transposition with optimal string alignment distance */
+            if (i > 1 && j > 1 && tolower(a[i - 1]) == tolower(b[j - 2]) && tolower(a[i - 2]) == tolower(b[j - 1])) {
+                mat[i * (b_len + 1) + j] = mii_min(mat[i * (b_len + 1) + j], mat[(i - 2) * (b_len + 1) + j - 2] + 1);
+            }
         }
     }
 


### PR DESCRIPTION
Use the optimal string alignment distance to check for transposition of two adjacent characters.
Source: [Damerau–Levenshtein distance](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance).

For example, without transposition, `sl` and `ls` have a distance of 2, but with transposition, they have a distance of 1. The command `ls` would then be positioned higher in the search results.

Thanks to @bartoldeman for the suggestion!