### PR TITLE
Add runtime interactive shell detection

### DIFF
--- a/init/bash
+++ b/init/bash
@@ -2,7 +2,7 @@
 # should be sourced from a bash shell
 
 # don't init in non-interactive shells
-[ -z "$PS1" ] && return
+[ $- != *i* ] && return
 
 # find a modules installation
 if ! type module 2>&1 >/dev/null; then

--- a/init/bash
+++ b/init/bash
@@ -30,8 +30,10 @@ fi
 command_not_found_handle() {
     # pass the command through mii if we are still interactive
     if [[ $- == *i* ]]; then
-        source $THISDIR/common $@
+        mii_common_force_disable=0
     else
-        $@
+        mii_common_force_disable=1
     fi
+
+    source $THISDIR/common $@
 }

--- a/init/bash
+++ b/init/bash
@@ -2,7 +2,7 @@
 # should be sourced from a bash shell
 
 # don't init in non-interactive shells
-[ $- != *i* ] && return
+[[ $- != *i* ]] && return
 
 # find a modules installation
 if ! type module 2>&1 >/dev/null; then
@@ -27,7 +27,11 @@ fi
 # synchronize the index quietly and quickly
 (mii sync 2>/dev/null &) 
 
-# execute the common handler
 command_not_found_handle() {
-    source $THISDIR/common $@
+    # pass the command through mii if we are still interactive
+    if [[ $- == *i* ]]; then
+        source $THISDIR/common $@
+    else
+        $@
+    fi
 }

--- a/init/common
+++ b/init/common
@@ -1,5 +1,10 @@
 # mii common handler
 
+# avoid calling mii, output an error message if we are non-interactive
+if [ $mii_common_force_disable ]; then
+    exec echo "$1: command not found!" 1>&2
+fi
+
 # grab status, don't do anything if not enabled
 state=$($MII status | grep "status" | cut -d' ' -f2)
 

--- a/init/zsh
+++ b/init/zsh
@@ -30,8 +30,10 @@ fi
 command_not_found_handler() {
     # pass the command through mii if we are still interactive
     if [[ -o interactive ]]; then
-        source $THISDIR/common $@
+        mii_common_force_disable=0
     else
-        $@
+        mii_common_force_disable=1
     fi
+
+    source $THISDIR/common $@
 }

--- a/init/zsh
+++ b/init/zsh
@@ -27,7 +27,11 @@ fi
 # synchronize the index quickly and quietly
 (mii sync 2>/dev/null &)
 
-# execute the common handler
 command_not_found_handler() {
-    source $THISDIR/common $@
+    # pass the command through mii if we are still interactive
+    if [[ -o interactive ]]; then
+        source $THISDIR/common $@
+    else
+        $@
+    fi
 }


### PR DESCRIPTION
This adds an interactive shell test at command time as well as init time. When a non-existing command is executed in a non-interactive shell a normal error message is displayed.

Fixes #12 