### PR TITLE
use gettext to get the command not found error localized

### DIFF
--- a/init/common
+++ b/init/common
@@ -3,7 +3,7 @@
 # return if it is interactive
 if [[ ! $- == *i* ]]; then
     # show a normal command not found prompt
-    exec echo "$1: command not found!" 1>&2
+    exec echo $0: $(printf "$(gettext bash '%s: command not found')" $1) 1>&2
 fi
 
 # grab status, don't do anything if not enabled
@@ -11,7 +11,7 @@ state=$($MII status | grep "status" | cut -d' ' -f2)
 
 if [ "$state" = "disabled" ]; then
     # show a normal command not found prompt
-    exec echo "$1: command not found!" 1>&2
+    exec echo $0: $(printf "$(gettext bash '%s: command not found')" $1) 1>&2
 fi
 
 # run mii select on the command, see if it returns OK


### PR DESCRIPTION
This is so that the "command not found" error get localized according to `LANG`. It also ensures that the error message is the same as what bash shows (it uses the `$0` in front of the error message). 