### PR TITLE
Add script source detection

### DIFF
--- a/init/bash
+++ b/init/bash
@@ -31,5 +31,8 @@ fi
 
 # execute the common handler
 command_not_found_handle() {
+    # check if being sourced
+    [[ -n "${BASH_SOURCE[1]}" ]] && SOURCED=1 || SOURCED=0
+
     source $THISDIR/common $@
 }

--- a/init/common
+++ b/init/common
@@ -1,8 +1,7 @@
 # mii common handler
 
-# return if it is interactive
-if [[ ! $- == *i* ]]; then
-    # show a normal command not found prompt
+# return if not interactive or sourced
+if [[ $- != *i* ]] || [[ "$SOURCED" = "1" ]]; then
     exec echo "$1: command not found!" 1>&2
 fi
 

--- a/init/zsh
+++ b/init/zsh
@@ -31,5 +31,8 @@ fi
 
 # execute the common handler
 command_not_found_handler() {
+    # check if sourced
+    [[ $ZSH_EVAL_CONTEXT =~ '.*file.*' ]] && SOURCED=1 || SOURCED=0
+
     source $THISDIR/common $@
 }


### PR DESCRIPTION
This PR addresses issue #17, adding a test before the common handler is called to check if the command is being run from a sourced script. Sourced commands are treated as a non-interactive shell.

Fixes #17