### PR TITLE
Fix option parsing in handler

### DIFF
--- a/init/common
+++ b/init/common
@@ -14,7 +14,7 @@ if [ "$state" = "disabled" ]; then
 fi
 
 # run mii select on the command, see if it returns OK
-mods=($($MII select "$1"))
+mods=($($MII select -- "$1"))
 res=$?
 
 if [ $res = 0 ]; then


### PR DESCRIPTION
This adds a '--' option terminator before the selection parameter in the `command_not_found_handler`, preventing mii from parsing options from user commands.

Fixes #28 